### PR TITLE
Copy only one pdf after building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ pdfs/%.pdf: build/%.tex
 	@[ -d $$(dirname $@) ] || mkdir -p $$(dirname $@)
 	@echo "Creating pdf: $@"
 	pdflatex -synctex=1 -interaction=nonstopmode -file-line-error -output-directory=$$(dirname $<) "$<"
-	cp "$$(find $$(dirname $<) -name '*.pdf')" "$$(dirname $@)/"
+	TEXFILE="$<"; \
+	cp "$${TEXFILE%.*}.pdf" "$@"
 
 build/%.tex: songs/%.tex template.tex
 	@[ -d $$(dirname $@) ] || mkdir -p $$(dirname $@)


### PR DESCRIPTION
Previously all pdf files of a build dir had been copied doing a single build.
Now only the built pdf from the make target will be copied.
This not only fits the make philosphy of "doing only what the target
specifies" better, but also fixes the issue of the build failing while having
more than one song of an interpret.

Fixes #9 